### PR TITLE
fix: only single index is assigned to rollup index after rollover

### DIFF
--- a/workflow-cli/configuration-opensearch/state_management_policy/nrm-type-accessrollup-rollover-policy.json
+++ b/workflow-cli/configuration-opensearch/state_management_policy/nrm-type-accessrollup-rollover-policy.json
@@ -16,6 +16,28 @@
             }
           }
         ],
+        "transitions": [{
+            "state_name": "alias",
+            "conditions": {
+              "min_doc_count": "2"
+            }
+          }]
+      },
+      {
+        "name": "alias",
+        "actions": [
+          {
+            "alias": {
+              "actions": [
+                {
+                  "remove": {
+                      "alias": "nrm-accessrollup"
+                  }
+                }
+              ]
+            }
+          }
+        ],
         "transitions": [
           {
             "state_name": "force_merge_standby",


### PR DESCRIPTION
fix: only single index is assigned to rollup index after rollover